### PR TITLE
Adding a "main" stanza for grunt-bower-install

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,11 @@
 {
   "name": "jquery-mobile-bower",
   "version": "1.4.1",
+  "main": [
+    "js/jquery.mobile-1.4.1.js",
+    "css/jquery.mobile-1.4.1.css"
+  ],
   "dependencies": {
     "jquery": "~1.10.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/jobrapido/jquery-mobile-bower.git"
   }
 }


### PR DESCRIPTION
The "repository" stanza isn't necessary (AFAIK, anyway) and the "main" one allows grunt-bower-install (Used by Yeoman and others) to automatically add the CSS/JS to project.
